### PR TITLE
Changed CSS to BEM format

### DIFF
--- a/assets/components/magicpreview/preview.css
+++ b/assets/components/magicpreview/preview.css
@@ -3,6 +3,7 @@ body.mmmp {
   margin: 0;
   font-family: -apple-system,sans-serif;
 }
+
 .mmmp-c-container {
   display: flex;
   flex-direction: column;
@@ -26,13 +27,16 @@ body.mmmp {
   margin: 1rem;
   font-size: 1rem;
 }
+
 .mmmp-c-title__span {
   color: hsla(213, 66%, 85%, 1);
 }
+
 .mmmp-c-title__link {
   color: hsla(213, 66%, 95%, 1);
   text-decoration: none;
 }
+
 .mmmp-c-title__link:hover,
 .mmmp-c-title__link:focus {
   text-decoration: underline;

--- a/assets/components/magicpreview/preview.css
+++ b/assets/components/magicpreview/preview.css
@@ -24,6 +24,7 @@ body.mmmp {
   color: hsla(213, 66%, 95%, 1);
   font-weight: lighter;
   margin: 1rem;
+  font-size: 1rem;
 }
 .mmmp-c-title__span {
   color: hsla(213, 66%, 85%, 1);
@@ -49,13 +50,13 @@ body.mmmp {
   opacity: 0;
 }
 
-.mmmp-c-breakpoints__input[type=radio]:focus + .mmmp-c-breakpoints__item-label,
+.mmmp-c-breakpoints__input[type=radio]:focus + .mmmp-c-breakpoints__item > .mmmp-c-breakpoints__item-label,
 .mmmp-c-breakpoints__item-label:hover {
   background: hsla(213, 66%, 45%, 1);
   color: hsla(213, 66%, 95%, 1);
 }
 
-.mmmp-c-breakpoints__input[type=radio]:checked + .mmmp-c-breakpoints__item-label {
+.mmmp-c-breakpoints__input[type=radio]:checked + .mmmp-c-breakpoints__item > .mmmp-c-breakpoints__item-label {
   background: hsla(213, 66%, 55%, 1);
   color: hsla(213, 66%, 95%, 1);
 }
@@ -69,6 +70,7 @@ body.mmmp {
   margin-right: -1px;
   cursor: pointer;
   box-shadow: inset 0 2px 2px hsla(0, 0%, 0%, 0.1), inset 0 -2px 0 hsla(0, 0%, 100%, 0.15);
+  font-size: 1rem;
 }
 
 .mmmp-c-breakpoints__item:first-of-type .mmmp-c-breakpoints__item-label {

--- a/assets/components/magicpreview/preview.css
+++ b/assets/components/magicpreview/preview.css
@@ -1,15 +1,15 @@
-body {
+body#mmmp {
   height: 100vh;
   margin: 0;
   font-family: -apple-system,sans-serif;
 }
-#container {
+.mmmp-c-container {
   display: flex;
   flex-direction: column;
   height: 100%;
 }
 
-#info {
+.mmmp-c-container__inner {
   background-color: #123764;
   color: #fff;
   margin: 0 auto;
@@ -20,87 +20,94 @@ body {
   align-items: center;
 }
 
-h1 {
+.mmmp-c-title {
   color: hsla(213, 66%, 95%, 1);
   font-weight: lighter;
   margin: 1rem;
 }
-h1 .preview-prefix {
+.mmmp-c-title__span {
   color: hsla(213, 66%, 85%, 1);
 }
-h1 a {
+.mmmp-c-title__link {
   color: hsla(213, 66%, 95%, 1);
   text-decoration: none;
 }
-h1 a:hover, h1 a:focus {
+.mmmp-c-title__link:hover,
+.mmmp-c-title__link:focus {
   text-decoration: underline;
 }
 
-.breakpoints {
+.mmmp-c-breakpoints {
   margin-left: auto;
   margin-right: 1rem;
   display: flex;
   position: relative;
 }
 
-input[type=radio] {
+.mmmp-c-breakpoints__input[type=radio] {
   position: absolute;
   opacity: 0;
 }
 
-input[type=radio]:focus + .breakpoint label, .breakpoint label:hover {
+.mmmp-c-breakpoints__input[type=radio]:focus + .mmmp-c-breakpoints__item-label,
+.mmmp-c-breakpoints__item-label:hover {
   background: hsla(213, 66%, 45%, 1);
   color: hsla(213, 66%, 95%, 1);
 }
 
-input[type=radio]:checked + .breakpoint label{
+.mmmp-c-breakpoints__input[type=radio]:checked + .mmmp-c-breakpoints__item-label {
   background: hsla(213, 66%, 55%, 1);
   color: hsla(213, 66%, 95%, 1);
 }
 
-.breakpoint label {
+.mmmp-c-breakpoints__item-label {
   display: block;
   position: relative;
   padding: 0.67rem 1rem;
   background: hsla(213, 66%, 35%, 1);
   color: hsla(213, 66%, 85%, 1);
-  /*border: 1px solid #fff;*/
   margin-right: -1px;
   cursor: pointer;
-
   box-shadow: inset 0 2px 2px hsla(0, 0%, 0%, 0.1), inset 0 -2px 0 hsla(0, 0%, 100%, 0.15);
 }
-.breakpoint:first-of-type label {
+
+.mmmp-c-breakpoints__item:first-of-type .mmmp-c-breakpoints__item-label {
   border-radius: 5px 0 0 5px;
 }
-.breakpoint:last-of-type label {
+
+.mmmp-c-breakpoints__item:last-of-type .mmmp-c-breakpoints__item-label {
   border-radius: 0 5px 5px 0;
 }
 
-#frame-wrapper, #loading-wrapper {
+.mmmp-c-frame,
+.mmmp-c-loading {
   display: flex;
   flex: 1;
 }
 
-#frame, #loading-wrapper p {
+.mmmp-c-frame__inner,
+.mmmp-c-loading__text {
   width: 100%;
   height: 100%;
   border: none;
 }
-#frame {
+
+.mmmp-c-frame__inner {
   border-left: 5px solid #ccc;
   border-right: 5px solid #ccc;
 }
-#frame-wrapper {
+
+.mmmp-c-frame {
   margin: 0 auto;
   width: 100%;
   transition: height 400ms ease, width 400ms ease;
 }
-#loading-wrapper {
+
+.mmmp-c-loading {
   text-align: center;
 }
-#loading-wrapper p {
+
+.mmmp-c-loading__text {
   padding-top: 5em;
   height: auto;
 }
-

--- a/assets/components/magicpreview/preview.css
+++ b/assets/components/magicpreview/preview.css
@@ -1,4 +1,4 @@
-body#mmmp {
+body.mmmp {
   height: 100vh;
   margin: 0;
   font-family: -apple-system,sans-serif;

--- a/core/components/magicpreview/templates/preview.tpl
+++ b/core/components/magicpreview/templates/preview.tpl
@@ -20,24 +20,24 @@
             </h1>
 
             <div class="mmmp-c-breakpoints">
-                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="full" id="mmmp-breakpoint-full" checked>
-                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
-                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-full">{$_lang['magicpreview.bp_full']}</label>
+                <input class="mmmp-c-breakpoints__input mmmp-js-breakpoint-input" type="radio" name="breakpoint" value="full" id="mmmp-breakpoint-full" checked>
+                <div class="mmmp-c-breakpoints__item">
+                    <label class="mmmp-c-breakpoints__item-label" for="mmmp-breakpoint-full">{$_lang['magicpreview.bp_full']}</label>
                 </div>
 
-                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="desktop" id="mmmp-breakpoint-desktop">
-                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
-                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-desktop">{$_lang['magicpreview.bp_desktop']}</label>
+                <input class="mmmp-c-breakpoints__input mmmp-js-breakpoint-input" type="radio" name="breakpoint" value="desktop" id="mmmp-breakpoint-desktop">
+                <div class="mmmp-c-breakpoints__item">
+                    <label class="mmmp-c-breakpoints__item-label" for="mmmp-breakpoint-desktop">{$_lang['magicpreview.bp_desktop']}</label>
                 </div>
 
-                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="tablet" id="mmmp-breakpoint-tablet">
-                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
-                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-tablet">{$_lang['magicpreview.bp_tablet']}</label>
+                <input class="mmmp-c-breakpoints__input mmmp-js-breakpoint-input" type="radio" name="breakpoint" value="tablet" id="mmmp-breakpoint-tablet">
+                <div class="mmmp-c-breakpoints__item">
+                    <label class="mmmp-c-breakpoints__item-label" for="mmmp-breakpoint-tablet">{$_lang['magicpreview.bp_tablet']}</label>
                 </div>
 
-                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="mobile" id="mmmp-breakpoint-mobile">
-                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
-                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-mobile">{$_lang['magicpreview.bp_mobile']}</label>
+                <input class="mmmp-c-breakpoints__input mmmp-js-breakpoint-input" type="radio" name="breakpoint" value="mobile" id="mmmp-breakpoint-mobile">
+                <div class="mmmp-c-breakpoints__item">
+                    <label class="mmmp-c-breakpoints__item-label" for="mmmp-breakpoint-mobile">{$_lang['magicpreview.bp_mobile']}</label>
                 </div>
             </div>
         </div>

--- a/core/components/magicpreview/templates/preview.tpl
+++ b/core/components/magicpreview/templates/preview.tpl
@@ -8,7 +8,7 @@
     <title>{$_lang['magicpreview.preview']} {$resource.pagetitle|escape}</title>
     <link rel="stylesheet" href="{$mp_config.assetsUrl}preview.css">
 </head>
-<body>
+<body class="mmmp">
 {if $resource['id'] > 0}
     <div class="mmmp-c-container">
         <div class="mmmp-c-container__inner">

--- a/core/components/magicpreview/templates/preview.tpl
+++ b/core/components/magicpreview/templates/preview.tpl
@@ -10,49 +10,49 @@
 </head>
 <body>
 {if $resource['id'] > 0}
-    <div id="container">
-        <div id="info">
-            <h1 class="resource">
-                <span class="preview-prefix">{$_lang['magicpreview.preview']}</span>
-                <a href="{$config.manager_url}?a=resource/update&id={$resource.id}">
+    <div class="mp-container">
+        <div class="mp-container__inner">
+            <h1 class="mp-title">
+                <span class="mp-title__span">{$_lang['magicpreview.preview']}</span>
+                <a class="mp-title__link" href="{$config.manager_url}?a=resource/update&id={$resource.id}">
                     {$resource.pagetitle|escape}
                 </a>
             </h1>
 
-            <div class="breakpoints">
-                <input type="radio" name="breakpoint" value="full" id="breakpoint-full" checked>
-                <div class="breakpoint">
-                    <label for="breakpoint-full">{$_lang['magicpreview.bp_full']}</label>
+            <div class="mp-breakpoints">
+                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="full" id="mp-breakpoint-full" checked>
+                <div class="breakpoints__item mp-js-breakpoint-input">
+                    <label class="breakpoints__item-label" for="breakpoint-full">{$_lang['magicpreview.bp_full']}</label>
                 </div>
 
-                <input type="radio" name="breakpoint" value="desktop" id="breakpoint-desktop">
-                <div class="breakpoint">
-                    <label for="breakpoint-desktop">{$_lang['magicpreview.bp_desktop']}</label>
+                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="desktop" id="mp-breakpoint-desktop">
+                <div class="breakpoints__item mp-js-breakpoint-input">
+                    <label class="breakpoints__item-label" for="breakpoint-desktop">{$_lang['magicpreview.bp_desktop']}</label>
                 </div>
 
-                <input type="radio" name="breakpoint" value="tablet" id="breakpoint-tablet">
-                <div class="breakpoint">
-                    <label for="breakpoint-tablet">{$_lang['magicpreview.bp_tablet']}</label>
+                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="tablet" id="mp-breakpoint-tablet">
+                <div class="breakpoints__item mp-js-breakpoint-input">
+                    <label class="breakpoints__item-label" for="breakpoint-tablet">{$_lang['magicpreview.bp_tablet']}</label>
                 </div>
 
-                <input type="radio" name="breakpoint" value="mobile" id="breakpoint-mobile">
-                <div class="breakpoint">
-                    <label for="breakpoint-mobile">{$_lang['magicpreview.bp_mobile']}</label>
+                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="mobile" id="mp-breakpoint-mobile">
+                <div class="breakpoints__item mp-js-breakpoint-input">
+                    <label class="breakpoints__item-label" for="breakpoint-mobile">{$_lang['magicpreview.bp_mobile']}</label>
                 </div>
             </div>
         </div>
-        <div id="frame-wrapper">
-            <iframe id="frame"></iframe>
+        <div class="mp-frame" id="mp-js-frame">
+            <iframe class="mp-frame__inner" id="mp-js-frame-inner"></iframe>
         </div>
-        <div id="loading-wrapper">
-            <p>{$_lang['magicpreview.preparing_preview']}</p>
+        <div class="mp-loading" id="mp-js-loading">
+            <p class="mp-loading__text">{$_lang['magicpreview.preparing_preview']}</p>
         </div>
     </div>
     <script>
         (function() {
-            var frame = document.getElementById('frame'),
-                frameWrapper = document.getElementById('frame-wrapper'),
-                loadingWrapper = document.getElementById('loading-wrapper'),
+            var frame = document.getElementById('mp-js-frame-inner'),
+                frameWrapper = document.getElementById('mp-js-frame'),
+                loadingWrapper = document.getElementById('mp-js-loading'),
                 baseFrameUrl = '{$baseFrameUrl|escape:javascript}',
                 joiner = baseFrameUrl.indexOf('?') === -1 ? '?' : '&';
             window.onhashchange = refreshFrame;
@@ -72,7 +72,7 @@
             }
 
             // Handle dynamic breakpoint sizing
-            var breakpoints = document.querySelectorAll('.breakpoints input');
+            var breakpoints = document.querySelectorAll('.mp-js-breakpoint-input');
             breakpoints.forEach(function(bp) {
                 bp.addEventListener('change', function () {
                     switch (this.value) {
@@ -97,9 +97,9 @@
         })()
     </script>
 {else}
-    <div id="container">
-        <div id="info">
-            <h1 class="resource">
+    <div class="mp-container">
+        <div class="mp-container__inner">
+            <h1 class="mp-title">
                 Resource not found
             </h1>
         </div>

--- a/core/components/magicpreview/templates/preview.tpl
+++ b/core/components/magicpreview/templates/preview.tpl
@@ -10,49 +10,49 @@
 </head>
 <body>
 {if $resource['id'] > 0}
-    <div class="mp-container">
-        <div class="mp-container__inner">
-            <h1 class="mp-title">
-                <span class="mp-title__span">{$_lang['magicpreview.preview']}</span>
-                <a class="mp-title__link" href="{$config.manager_url}?a=resource/update&id={$resource.id}">
+    <div class="mmmp-c-container">
+        <div class="mmmp-c-container__inner">
+            <h1 class="mmmp-c-title">
+                <span class="mmmp-c-title__span">{$_lang['magicpreview.preview']}</span>
+                <a class="mmmp-c-title__link" href="{$config.manager_url}?a=resource/update&id={$resource.id}">
                     {$resource.pagetitle|escape}
                 </a>
             </h1>
 
-            <div class="mp-breakpoints">
-                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="full" id="mp-breakpoint-full" checked>
-                <div class="breakpoints__item mp-js-breakpoint-input">
-                    <label class="breakpoints__item-label" for="breakpoint-full">{$_lang['magicpreview.bp_full']}</label>
+            <div class="mmmp-c-breakpoints">
+                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="full" id="mmmp-breakpoint-full" checked>
+                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
+                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-full">{$_lang['magicpreview.bp_full']}</label>
                 </div>
 
-                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="desktop" id="mp-breakpoint-desktop">
-                <div class="breakpoints__item mp-js-breakpoint-input">
-                    <label class="breakpoints__item-label" for="breakpoint-desktop">{$_lang['magicpreview.bp_desktop']}</label>
+                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="desktop" id="mmmp-breakpoint-desktop">
+                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
+                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-desktop">{$_lang['magicpreview.bp_desktop']}</label>
                 </div>
 
-                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="tablet" id="mp-breakpoint-tablet">
-                <div class="breakpoints__item mp-js-breakpoint-input">
-                    <label class="breakpoints__item-label" for="breakpoint-tablet">{$_lang['magicpreview.bp_tablet']}</label>
+                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="tablet" id="mmmp-breakpoint-tablet">
+                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
+                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-tablet">{$_lang['magicpreview.bp_tablet']}</label>
                 </div>
 
-                <input class="mp-breakpoints__input" type="radio" name="breakpoint" value="mobile" id="mp-breakpoint-mobile">
-                <div class="breakpoints__item mp-js-breakpoint-input">
-                    <label class="breakpoints__item-label" for="breakpoint-mobile">{$_lang['magicpreview.bp_mobile']}</label>
+                <input class="mmmp-c-breakpoints__input" type="radio" name="breakpoint" value="mobile" id="mmmp-breakpoint-mobile">
+                <div class="mmmp-c-breakpoints__item mmmp-js-breakpoint-input">
+                    <label class="mmmp-c-breakpoints__item-label" for="breakpoint-mobile">{$_lang['magicpreview.bp_mobile']}</label>
                 </div>
             </div>
         </div>
-        <div class="mp-frame" id="mp-js-frame">
-            <iframe class="mp-frame__inner" id="mp-js-frame-inner"></iframe>
+        <div class="mmmp-c-frame" id="mmmp-js-frame">
+            <iframe class="mmmp-c-frame__inner" id="mmmp-js-frame-inner"></iframe>
         </div>
-        <div class="mp-loading" id="mp-js-loading">
-            <p class="mp-loading__text">{$_lang['magicpreview.preparing_preview']}</p>
+        <div class="mmmp-c-loading" id="mmmp-js-loading">
+            <p class="mmmp-c-loading__text">{$_lang['magicpreview.preparing_preview']}</p>
         </div>
     </div>
     <script>
         (function() {
-            var frame = document.getElementById('mp-js-frame-inner'),
-                frameWrapper = document.getElementById('mp-js-frame'),
-                loadingWrapper = document.getElementById('mp-js-loading'),
+            var frame = document.getElementById('mmmp-js-frame-inner'),
+                frameWrapper = document.getElementById('mmmp-js-frame'),
+                loadingWrapper = document.getElementById('mmmp-js-loading'),
                 baseFrameUrl = '{$baseFrameUrl|escape:javascript}',
                 joiner = baseFrameUrl.indexOf('?') === -1 ? '?' : '&';
             window.onhashchange = refreshFrame;
@@ -72,7 +72,7 @@
             }
 
             // Handle dynamic breakpoint sizing
-            var breakpoints = document.querySelectorAll('.mp-js-breakpoint-input');
+            var breakpoints = document.querySelectorAll('.mmmp-js-breakpoint-input');
             breakpoints.forEach(function(bp) {
                 bp.addEventListener('change', function () {
                     switch (this.value) {
@@ -97,9 +97,9 @@
         })()
     </script>
 {else}
-    <div class="mp-container">
-        <div class="mp-container__inner">
-            <h1 class="mp-title">
+    <div class="mmmp-c-container">
+        <div class="mmmp-c-container__inner">
+            <h1 class="mmmp-c-title mmmp-c-title--error">
                 Resource not found
             </h1>
         </div>


### PR DESCRIPTION
Admittedly, I hadn't realised MagicPreview loads the preview page via an iFrame. Having reviewed the HTML and seeing Rob on Slack mention something about this, I thought it might be wise to `namespace` the CSS. 

Now, I realise that MagicPreview styles won't interfere with preview page styles. So what are the actual benefits of this PR other than doing a bem-dump over your CSS!

1. BEM format is easier to follow if somebody wants to customise the toolbar
2. It creates specific class names for elements that are being manipulated via the dom
3. It adds a font-size of 1rem to the header and breakpoints :) 

No worries if you don't want to accept this PR!