### PR TITLE
MODX 3 Compatibility - Split Processors

### DIFF
--- a/assets/components/magicpreview/connector.php
+++ b/assets/components/magicpreview/connector.php
@@ -7,6 +7,11 @@ $corePath = $modx->getOption('magicpreview.core_path',null,$modx->getOption('cor
 $modx->getService('magicpreview', 'MagicPreview', $corePath . 'model/magicpreview/');
 //$modx->lexicon->load('magicpreview:default');
 
+// Check for MODX version
+if (version_compare($modx->getOption('settings_version'), '3.0.0-alpha1') < 1) {
+    // Switch to the old version of the processor if less that 3.0.0-alpha1 (i.e. for any 2.x release)
+    $_REQUEST['action'] = 'resource/preview-v2';
+}
 
 /* handle request */
 $path = $modx->getOption('processorsPath', $modx->magicpreview->config,$corePath  .'processors/');

--- a/core/components/magicpreview/processors/resource/PreviewTrait.php
+++ b/core/components/magicpreview/processors/resource/PreviewTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This trait includes overridden update processor methods that both 2.x and 3.x processors need.
+ */
+trait PreviewTrait
+{
+    private $previewHash;
+    private $failedSuccessfully = false;
+
+    public function fireBeforeSaveEvent()
+    {
+        // Invoke an event to allow other modules to prepare/modify the resource before preview.
+        $this->modx->invokeEvent('OnResourceMagicPreview', [
+            'resource' => $this->object
+        ]);
+
+        $this->failedSuccessfully = true;
+
+        if ($tvs = $this->object->getMany('TemplateVars', 'all')) {
+            /** @var modTemplateVar $tv */
+            foreach ($tvs as $tv) {
+                $this->object->set($tv->get('name'), [
+                    $tv->get('name'),
+                    $this->object->get('tv' . $tv->get('id')),
+                    $tv->get('display'),
+                    $tv->get('display_params'),
+                    $tv->get('type'),
+                ]);
+            }
+        }
+        $data = $this->object->toArray('', true);
+
+        $key = bin2hex(random_bytes(12));
+        $this->modx->cacheManager->set($this->object->get('id') . '/' . $key, $data, 3600, [
+            xPDO::OPT_CACHE_KEY => 'magicpreview'
+        ]);
+        $this->previewHash = $key;
+
+        return false;
+    }
+
+    public function failure($msg = '',$object = null) {
+        if ($this->failedSuccessfully) {
+            return $this->success('', [
+                'preview_hash' => $this->previewHash,
+            ]);
+        }
+        return parent::failure($msg, $object);
+    }
+
+    /**
+     * Always prevent actual saving
+     * @return bool
+     */
+    public function saveObject()
+    {
+        return false;
+    }
+}

--- a/core/components/magicpreview/processors/resource/preview-v2.class.php
+++ b/core/components/magicpreview/processors/resource/preview-v2.class.php
@@ -1,62 +1,14 @@
 <?php
 
+require 'PreviewTrait.php';
 require MODX_PROCESSORS_PATH . 'resource/update.class.php';
 
 class MagicPreviewPreviewProcessorV2 extends modResourceUpdateProcessor {
-    private $previewHash;
-    private $failedSuccessfully = false;
+
+    use PreviewTrait;
 
     public static function getInstance(modX &$modx, $className, $properties = array()) {
         return new self($modx, $properties);
-    }
-
-    public function fireBeforeSaveEvent() {
-        // Invoke an event to allow other modules to prepare/modify the resource before preview.
-        $this->modx->invokeEvent('OnResourceMagicPreview', [
-            'resource' => $this->object
-        ]);
-
-        $this->failedSuccessfully = true;
-
-        if ($tvs = $this->object->getMany('TemplateVars', 'all')) {
-            /** @var modTemplateVar $tv */
-            foreach ($tvs as $tv) {
-                $this->object->set($tv->get('name'), [
-                    $tv->get('name'),
-                    $this->object->get('tv' . $tv->get('id')),//$tv->getValue($resource->get('id')),
-                    $tv->get('display'),
-                    $tv->get('display_params'),
-                    $tv->get('type'),
-                ]);
-            }
-        }
-        $data = $this->object->toArray('', true);
-
-        $key = bin2hex(random_bytes(12));
-        $this->modx->cacheManager->set($this->object->get('id') . '/' . $key, $data, 3600, [
-            xPDO::OPT_CACHE_KEY => 'magicpreview'
-        ]);
-        $this->previewHash = $key;
-
-        return false;
-    }
-
-    public function failure($msg = '',$object = null) {
-        if ($this->failedSuccessfully) {
-            return $this->success('', [
-                'preview_hash' => $this->previewHash,
-            ]);
-        }
-        return parent::failure($msg, $object);
-    }
-
-    /**
-     * Always prevent actual saving
-     * @return bool
-     */
-    public function saveObject()
-    {
-        return false;
     }
 }
 

--- a/core/components/magicpreview/processors/resource/preview-v2.class.php
+++ b/core/components/magicpreview/processors/resource/preview-v2.class.php
@@ -1,12 +1,12 @@
 <?php
 
-use MODX\Revolution\Processors\Resource\Update;
+require MODX_PROCESSORS_PATH . 'resource/update.class.php';
 
-class MagicPreviewPreviewProcessor extends Update {
+class MagicPreviewPreviewProcessorV2 extends modResourceUpdateProcessor {
     private $previewHash;
     private $failedSuccessfully = false;
 
-    public static function getInstance(modX $modx, $className, $properties = []) {
+    public static function getInstance(modX &$modx, $className, $properties = array()) {
         return new self($modx, $properties);
     }
 
@@ -60,4 +60,4 @@ class MagicPreviewPreviewProcessor extends Update {
     }
 }
 
-return 'MagicPreviewPreviewProcessor';
+return 'MagicPreviewPreviewProcessorV2';

--- a/core/components/magicpreview/processors/resource/preview.class.php
+++ b/core/components/magicpreview/processors/resource/preview.class.php
@@ -2,61 +2,14 @@
 
 use MODX\Revolution\Processors\Resource\Update;
 
+require 'PreviewTrait.php';
+
 class MagicPreviewPreviewProcessor extends Update {
-    private $previewHash;
-    private $failedSuccessfully = false;
+
+    use PreviewTrait;
 
     public static function getInstance(modX $modx, $className, $properties = []) {
         return new self($modx, $properties);
-    }
-
-    public function fireBeforeSaveEvent() {
-        // Invoke an event to allow other modules to prepare/modify the resource before preview.
-        $this->modx->invokeEvent('OnResourceMagicPreview', [
-            'resource' => $this->object
-        ]);
-
-        $this->failedSuccessfully = true;
-
-        if ($tvs = $this->object->getMany('TemplateVars', 'all')) {
-            /** @var modTemplateVar $tv */
-            foreach ($tvs as $tv) {
-                $this->object->set($tv->get('name'), [
-                    $tv->get('name'),
-                    $this->object->get('tv' . $tv->get('id')),//$tv->getValue($resource->get('id')),
-                    $tv->get('display'),
-                    $tv->get('display_params'),
-                    $tv->get('type'),
-                ]);
-            }
-        }
-        $data = $this->object->toArray('', true);
-
-        $key = bin2hex(random_bytes(12));
-        $this->modx->cacheManager->set($this->object->get('id') . '/' . $key, $data, 3600, [
-            xPDO::OPT_CACHE_KEY => 'magicpreview'
-        ]);
-        $this->previewHash = $key;
-
-        return false;
-    }
-
-    public function failure($msg = '',$object = null) {
-        if ($this->failedSuccessfully) {
-            return $this->success('', [
-                'preview_hash' => $this->previewHash,
-            ]);
-        }
-        return parent::failure($msg, $object);
-    }
-
-    /**
-     * Always prevent actual saving
-     * @return bool
-     */
-    public function saveObject()
-    {
-        return false;
     }
 }
 


### PR DESCRIPTION
Creating this as a PR because it may not be the preferred approach.

The connector now checks the MODX version and if less than 3.0.0-alpha1 will send the request to the old version of the processor.
Above that is sent to the new "default" version.

Even though it duplicates code, my vote is with this method as I believe the `getInstance()` method must have been overridden for a reason (even though it's not clear to me what 😄).
