### PR TITLE
Fix relative paths

### DIFF
--- a/core/components/magicpreview/processors/resource/preview-v2.class.php
+++ b/core/components/magicpreview/processors/resource/preview-v2.class.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'PreviewTrait.php';
+require __DIR__ . '/PreviewTrait.php';
 require MODX_PROCESSORS_PATH . 'resource/update.class.php';
 
 class MagicPreviewPreviewProcessorV2 extends modResourceUpdateProcessor {

--- a/core/components/magicpreview/processors/resource/preview.class.php
+++ b/core/components/magicpreview/processors/resource/preview.class.php
@@ -2,7 +2,7 @@
 
 use MODX\Revolution\Processors\Resource\Update;
 
-require 'PreviewTrait.php';
+require __DIR__ . '/PreviewTrait.php';
 
 class MagicPreviewPreviewProcessor extends Update {
 


### PR DESCRIPTION
It's best to always use a full path (in this case, concatenating the current directory) so PHP doesn't go searching along any potentially configured `include_path`s. 