### PR TITLE
Close tab/window when clicking title

### DIFF
--- a/core/components/magicpreview/templates/preview.tpl
+++ b/core/components/magicpreview/templates/preview.tpl
@@ -14,7 +14,7 @@
         <div class="mmmp-c-container__inner">
             <h1 class="mmmp-c-title">
                 <span class="mmmp-c-title__span">{$_lang['magicpreview.preview']}</span>
-                <a class="mmmp-c-title__link" href="{$config.manager_url}?a=resource/update&id={$resource.id}">
+                <a class="mmmp-c-title__link" id="mmmp-title-link" href="{$config.manager_url}?a=resource/update&id={$resource.id}">
                     {$resource.pagetitle|escape}
                 </a>
             </h1>
@@ -57,7 +57,8 @@
                 frameWrapper = document.getElementById('mmmp-js-frame'),
                 loadingWrapper = document.getElementById('mmmp-js-loading'),
                 baseFrameUrl = '{$baseFrameUrl|escape:javascript}',
-                joiner = baseFrameUrl.indexOf('?') === -1 ? '?' : '&';
+                joiner = baseFrameUrl.indexOf('?') === -1 ? '?' : '&',
+                titleLink = document.getElementById('mmmp-title-link');
             window.onhashchange = refreshFrame;
             refreshFrame();
 
@@ -96,6 +97,12 @@
                             break;
                     }
                 });
+            });
+
+            // Close the preview tab/window on title click
+            titleLink.addEventListener('click', function(e) {
+                e.preventDefault();
+                window.close();
             });
         })()
     </script>


### PR DESCRIPTION
This small alteration will close the preview tab when clicking the title.

This is a change from where clicking the title currently reloads the resource edit page in the same tab. When it's loaded the resource doesn't have the unsaved changes applied so it can be confusing for the editor.

I'm of two minds about this... if the user has come straight to the preview and then clicks the title to close, they'll be taken back to the resource edit page that's still open in the previous tab. This is good! 😃 
But, if they've moved to another tab then come back and close it, it would be the previous tab that's focused of course.

Perhaps a close preview button would be better somewhere with the title made to be just text rather than a link.
All feedback welcome! 

Related to https://github.com/modmore/MagicPreview/issues/18