### PR TITLE
Fix fatal error

### DIFF
--- a/core/components/magicpreview/processors/resource/preview-v2.class.php
+++ b/core/components/magicpreview/processors/resource/preview-v2.class.php
@@ -1,7 +1,7 @@
 <?php
 
 require __DIR__ . '/PreviewTrait.php';
-require MODX_PROCESSORS_PATH . 'resource/update.class.php';
+require_once MODX_PROCESSORS_PATH . 'resource/update.class.php';
 
 class MagicPreviewPreviewProcessorV2 extends modResourceUpdateProcessor {
 


### PR DESCRIPTION
I tracked down what was trying to re-include `resource/update.class.php`. But not why or how my site differs from the MODX 2.X ones you've tested on.

Fixes #23