### PR TITLE
Merge MagicPreview and View button

### DIFF
--- a/assets/components/magicpreview/css/mgr.css
+++ b/assets/components/magicpreview/css/mgr.css
@@ -1,0 +1,13 @@
+#modx-abtn-preview {
+    margin-left: -.6rem !important;
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+}
+    
+#modx-abtn-preview:before {
+    content: "↗";
+}
+
+#modx-abtn-preview .x-btn-text {        
+    text-indent: -1000px;
+}

--- a/assets/components/magicpreview/js/preview.js
+++ b/assets/components/magicpreview/js/preview.js
@@ -26,7 +26,8 @@
             },
             getButtons: function(config) {
                 var btns = this._originals.getButtons.call(this, config);
-                btns.splice(2, 0, {
+                var btnView = btns.map((btn) => { return btn.id }).indexOf("modx-abtn-preview");
+                btns.splice(btnView, 0, {
                     text: 'Preview',
                     id: 'modx-abtn-real-preview',
                     handler: this.mpPreview,

--- a/core/components/magicpreview/elements/plugins/magicpreview.plugin.php
+++ b/core/components/magicpreview/elements/plugins/magicpreview.plugin.php
@@ -14,10 +14,17 @@ switch ($modx->event->name) {
     case 'OnDocFormRender':
         if ($resource->get('id') > 0) {
             $modx->controller->addJavascript($service->config['assetsUrl'] . 'js/preview.js?v=' . $service::VERSION);
-            $modx->controller->addHtml('<script>
-    MagicPreviewConfig = ' . json_encode($service->config) . ';
-    MagicPreviewResource = ' . $resource->get('id') . ';
-    </script>');
+            $modx->controller->addHtml('
+                <link
+                    rel="stylesheet"
+                    type="text/css"
+                    href="' . $service->config['assetsUrl'] . 'css/mgr.css?v=' . $service::VERSION . '"
+                />
+                <script>
+                    MagicPreviewConfig = ' . json_encode($service->config) . ';
+                    MagicPreviewResource = ' . $resource->get('id') . ';
+                </script>
+            ');
         }
         break;
 


### PR DESCRIPTION
The two buttons on the Resource Edit form are a little confusing: one for a live preview and one for a preview when saving. Combining the two is better UX and saves space.

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/310f64c4-621b-49bf-9fd1-f060d4be9c0a">
