### PR TITLE
Bugfix TV Preview with multiselect and delimiter

### DIFF
--- a/core/components/magicpreview/processors/resource/PreviewTrait.php
+++ b/core/components/magicpreview/processors/resource/PreviewTrait.php
@@ -23,7 +23,7 @@ trait PreviewTrait
             foreach ($tvs as $tv) {
                 $this->object->set($tv->get('name'), [
                     $tv->get('name'),
-                    $this->object->get('tv' . $tv->get('id')),
+                    $this->modx->getObject('modTemplateVar', $tv->get('id'))->renderOutput($this->object->get('id')),
                     $tv->get('display'),
                     $tv->get('display_params'),
                     $tv->get('type'),


### PR DESCRIPTION
I have a resource with a TV connected as a multiselect and a delimiter output. The value in the cache is stored as an array:

```
'connectedProjects' => 
  array (
    0 => 'connectedProjects',
    1 => 
    array (
      0 => '210',
      1 => '224',
      2 => '253',
    ),
    2 => 'delim',
    3 => NULL,
    4 => 'listbox-multiple',
  ),
```

But when looking in the resource cache it should be like this:

```
'connectedProjects' => 
  array (
    0 => 'connectedProjects',
    1 => "210||224||253",
    2 => 'delim',
    3 => NULL,
    4 => 'listbox-multiple',
  ),
```

So I try to render the TV before saving the cache. There may be a nicer way, but this works for me now.

Side issue: I have an output filter for a pdoMenu snippet. But when using this with a value as an array, it ends in a fatal error because an array is given, not a string (PHP 8.3). This causes the preview to crash.