### PR TITLE
Move MODX 3.x resource sidebar when opening on page preview

### DIFF
--- a/assets/components/magicpreview/css/mgr.css
+++ b/assets/components/magicpreview/css/mgr.css
@@ -207,6 +207,28 @@ body.magicpreview_modx2:has(.mmmp-draft-banner) #modx-action-buttons {
 }
 
 /* --------------------------------------------------------------------------
+   On-page layout: resource sidebar repositioned to bottom
+
+   When on-page preview is active, the resource editor's right column
+   (#modx-resource-main-right: Template, Published, etc.) stacks below the
+   main left column (#modx-resource-main-left) so the editor gets full width.
+   -------------------------------------------------------------------------- */
+
+body.mmmp-panel-onpage-active .x-panel-body {
+    width: 100% !important;
+}
+
+body.mmmp-panel-onpage-active #modx-resource-main-left {
+    width: calc(100% - 30px) !important;
+}
+
+body.mmmp-panel-onpage-active #modx-resource-main-right {
+    width: 100% !important;
+    margin-top: 15px !important;
+    margin-left: 0 !important;
+}
+
+/* --------------------------------------------------------------------------
    Preview Panel: resize handle
    A thin invisible strip along the left edge of the panel that the user
    can click and drag to resize the panel horizontally.

--- a/assets/components/magicpreview/css/mgr.css
+++ b/assets/components/magicpreview/css/mgr.css
@@ -213,6 +213,10 @@ body.magicpreview_modx2:has(.mmmp-draft-banner) #modx-action-buttons {
    (#modx-resource-main-right: Template, Published, etc.) stacks below the
    main left column (#modx-resource-main-left) so the editor gets full width.
 
+   The 15px gaps match MODX's native column gutter (its own responsive CSS
+   stacks these columns the same way under ~1140px); the left column drops
+   30px (2x that gutter) so full width clears it without a horizontal scrollbar.
+
    MODX 3.x only — MODX 2.x has no resource sidebar, so these rules would
    distort its single-column layout.
    -------------------------------------------------------------------------- */

--- a/assets/components/magicpreview/css/mgr.css
+++ b/assets/components/magicpreview/css/mgr.css
@@ -212,17 +212,20 @@ body.magicpreview_modx2:has(.mmmp-draft-banner) #modx-action-buttons {
    When on-page preview is active, the resource editor's right column
    (#modx-resource-main-right: Template, Published, etc.) stacks below the
    main left column (#modx-resource-main-left) so the editor gets full width.
+
+   MODX 3.x only — MODX 2.x has no resource sidebar, so these rules would
+   distort its single-column layout.
    -------------------------------------------------------------------------- */
 
-body.mmmp-panel-onpage-active .x-panel-body {
+body.magicpreview_modx3.mmmp-panel-onpage-active .x-panel-body {
     width: 100% !important;
 }
 
-body.mmmp-panel-onpage-active #modx-resource-main-left {
+body.magicpreview_modx3.mmmp-panel-onpage-active #modx-resource-main-left {
     width: calc(100% - 30px) !important;
 }
 
-body.mmmp-panel-onpage-active #modx-resource-main-right {
+body.magicpreview_modx3.mmmp-panel-onpage-active #modx-resource-main-right {
     width: 100% !important;
     margin-top: 15px !important;
     margin-left: 0 !important;

--- a/assets/components/magicpreview/css/mgr.css
+++ b/assets/components/magicpreview/css/mgr.css
@@ -217,7 +217,7 @@ body.magicpreview_modx2:has(.mmmp-draft-banner) #modx-action-buttons {
    distort its single-column layout.
    -------------------------------------------------------------------------- */
 
-body.magicpreview_modx3.mmmp-panel-onpage-active .x-panel-body {
+body.magicpreview_modx3.mmmp-panel-onpage-active #modx-resource-main-columns .x-panel-body {
     width: 100% !important;
 }
 


### PR DESCRIPTION
It'll automatically stack below the main columns. Only affects MODX 3.x.