### PR TITLE
Enable/disable previewing by template id or by resource option

### DIFF
--- a/_build/data/settings.php
+++ b/_build/data/settings.php
@@ -36,6 +36,15 @@ return [
         'value' => '5',
         'xtype' => 'numberfield',
     ],
+    'template_filter_mode' => [
+        'area' => 'Visibility',
+        'value' => 'None',
+        'xtype' => 'magicpreview-combo-template-filter-mode',
+    ],
+    'template_filter_ids' => [
+        'area' => 'Visibility',
+        'value' => '',
+    ],
     'draft_ttl' => [
         'area' => 'Drafts',
         'value' => '0',

--- a/assets/components/magicpreview/css/mgr.css
+++ b/assets/components/magicpreview/css/mgr.css
@@ -109,14 +109,14 @@ body.magicpreview_modx2:has(.mmmp-draft-banner) #modx-action-buttons {
     padding-right: 0;
 }
 
-#modx-action-buttons .x-toolbar-cell:has(> #modx-abtn-preview) {
+.magicpreview_active #modx-action-buttons .x-toolbar-cell:has(> #modx-abtn-preview) {
     padding-left: 0;
 }
 
 /* -- MODX 2: eliminate margin between merged buttons --------------------- */
 
 .magicpreview_modx2 #modx-abtn-save-draft,
-.magicpreview_modx2 #modx-abtn-preview {
+.magicpreview_active.magicpreview_modx2 #modx-abtn-preview {
     margin-left: 0 !important;
 }
 
@@ -137,7 +137,7 @@ body.magicpreview_modx2:has(.mmmp-draft-banner) #modx-action-buttons {
     border-right: 1px solid #E4E4E4 !important;
 }
 
-#modx-abtn-preview {
+.magicpreview_active #modx-abtn-preview {
     border-top-left-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
 }

--- a/assets/components/magicpreview/js/combo.js
+++ b/assets/components/magicpreview/js/combo.js
@@ -26,20 +26,12 @@ function getSystemDefaultLabel() {
 }
 
 /**
- * Preview Mode combo: New Window or Panel.
+ * Base combo: shared config for every MagicPreview settings dropdown.
+ * Subclasses supply their own store, displayField and valueField.
  */
-MagicPreview.combo.PreviewMode = function(config) {
+MagicPreview.combo.Base = function(config) {
     config = config || {};
     Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v'],
-            data: [
-                ['New Window'],
-                ['Panel']
-            ]
-        }),
-        displayField: 'v',
-        valueField: 'v',
         mode: 'local',
         triggerAction: 'all',
         editable: false,
@@ -48,9 +40,51 @@ MagicPreview.combo.PreviewMode = function(config) {
         forceSelection: true,
         enableKeyEvents: true
     });
+    MagicPreview.combo.Base.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.Base, MODx.combo.ComboBox);
+
+/**
+ * Base for per-resource combos: prepends a localised "System Default" row
+ * (value 'system_default', cleared to '' on save) ahead of the subclass's
+ * own rows. Subclasses pass their [value, label] pairs via config.rows.
+ * Rows are read at construction time so labels that depend on
+ * MagicPreviewConfig (injected lazily) resolve correctly.
+ */
+MagicPreview.combo.ResourceBase = function(config) {
+    config = config || {};
+    var rows = config.rows || [];
+    delete config.rows;
+    Ext.applyIf(config, {
+        store: new Ext.data.SimpleStore({
+            fields: ['v', 'd'],
+            data: [['system_default', getSystemDefaultLabel()]].concat(rows)
+        }),
+        displayField: 'd',
+        valueField: 'v'
+    });
+    MagicPreview.combo.ResourceBase.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.ResourceBase, MagicPreview.combo.Base);
+
+// -- System settings combos --------------------------------------------------
+
+/**
+ * Preview Mode combo: New Window or Panel.
+ */
+MagicPreview.combo.PreviewMode = function(config) {
+    config = config || {};
+    Ext.applyIf(config, {
+        store: new Ext.data.SimpleStore({
+            fields: ['v'],
+            data: [['New Window'], ['Panel']]
+        }),
+        displayField: 'v',
+        valueField: 'v'
+    });
     MagicPreview.combo.PreviewMode.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.PreviewMode, MODx.combo.ComboBox);
+Ext.extend(MagicPreview.combo.PreviewMode, MagicPreview.combo.Base);
 Ext.reg('magicpreview-combo-preview-mode', MagicPreview.combo.PreviewMode);
 
 /**
@@ -61,55 +95,15 @@ MagicPreview.combo.PanelLayout = function(config) {
     Ext.applyIf(config, {
         store: new Ext.data.SimpleStore({
             fields: ['v'],
-            data: [
-                ['Overlay'],
-                ['On Page']
-            ]
+            data: [['Overlay'], ['On Page']]
         }),
         displayField: 'v',
-        valueField: 'v',
-        mode: 'local',
-        triggerAction: 'all',
-        editable: false,
-        selectOnFocus: false,
-        preventRender: true,
-        forceSelection: true,
-        enableKeyEvents: true
+        valueField: 'v'
     });
     MagicPreview.combo.PanelLayout.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.PanelLayout, MODx.combo.ComboBox);
+Ext.extend(MagicPreview.combo.PanelLayout, MagicPreview.combo.Base);
 Ext.reg('magicpreview-combo-panel-layout', MagicPreview.combo.PanelLayout);
-
-/**
- * Preview Mode combo for resource settings: includes a "System Default"
- * option (empty string value) that inherits from the system setting.
- */
-MagicPreview.combo.PreviewModeResource = function(config) {
-    config = config || {};
-    Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v', 'd'],
-            data: [
-                ['system_default', getSystemDefaultLabel()],
-                ['New Window', 'New Window'],
-                ['Panel', 'Panel']
-            ]
-        }),
-        displayField: 'd',
-        valueField: 'v',
-        mode: 'local',
-        triggerAction: 'all',
-        editable: false,
-        selectOnFocus: false,
-        preventRender: true,
-        forceSelection: true,
-        enableKeyEvents: true
-    });
-    MagicPreview.combo.PreviewModeResource.superclass.constructor.call(this, config);
-};
-Ext.extend(MagicPreview.combo.PreviewModeResource, MODx.combo.ComboBox);
-Ext.reg('magicpreview-combo-preview-mode-resource', MagicPreview.combo.PreviewModeResource);
 
 /**
  * Template Filter Mode combo for system settings.
@@ -119,89 +113,58 @@ MagicPreview.combo.TemplateFilterMode = function(config) {
     Ext.applyIf(config, {
         store: new Ext.data.SimpleStore({
             fields: ['v'],
-            data: [
-                ['None'],
-                ['Block Listed'],
-                ['Allow Listed Only']
-            ]
+            data: [['None'], ['Block Listed'], ['Allow Listed Only']]
         }),
         displayField: 'v',
-        valueField: 'v',
-        mode: 'local',
-        triggerAction: 'all',
-        editable: false,
-        selectOnFocus: false,
-        preventRender: true,
-        forceSelection: true,
-        enableKeyEvents: true
+        valueField: 'v'
     });
     MagicPreview.combo.TemplateFilterMode.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.TemplateFilterMode, MODx.combo.ComboBox);
+Ext.extend(MagicPreview.combo.TemplateFilterMode, MagicPreview.combo.Base);
 Ext.reg('magicpreview-combo-template-filter-mode', MagicPreview.combo.TemplateFilterMode);
 
-/**
- * Per-resource enabled override combo: System Default / Yes / No.
- * Inherits from the template filter system setting when "System Default".
- */
-MagicPreview.combo.ResourceEnabled = function(config) {
-    config = config || {};
-    var labelYes = (typeof MagicPreviewConfig !== 'undefined'
-        && MagicPreviewConfig.lexicon
-        && MagicPreviewConfig.lexicon.yes) || 'Yes';
-    var labelNo = (typeof MagicPreviewConfig !== 'undefined'
-        && MagicPreviewConfig.lexicon
-        && MagicPreviewConfig.lexicon.no) || 'No';
-    Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v', 'd'],
-            data: [
-                ['system_default', getSystemDefaultLabel()],
-                ['Yes', labelYes],
-                ['No', labelNo]
-            ]
-        }),
-        displayField: 'd',
-        valueField: 'v',
-        mode: 'local',
-        triggerAction: 'all',
-        editable: false,
-        selectOnFocus: false,
-        preventRender: true,
-        forceSelection: true,
-        enableKeyEvents: true
-    });
-    MagicPreview.combo.ResourceEnabled.superclass.constructor.call(this, config);
-};
-Ext.extend(MagicPreview.combo.ResourceEnabled, MODx.combo.ComboBox);
-Ext.reg('magicpreview-combo-resource-enabled', MagicPreview.combo.ResourceEnabled);
+// -- Per-resource combos (include a "System Default" inherit option) ---------
 
 /**
- * Panel Layout combo for resource settings: includes a "System Default"
- * option (empty string value) that inherits from the system setting.
+ * Preview Mode combo for resource settings.
+ */
+MagicPreview.combo.PreviewModeResource = function(config) {
+    config = config || {};
+    Ext.applyIf(config, {
+        rows: [['New Window', 'New Window'], ['Panel', 'Panel']]
+    });
+    MagicPreview.combo.PreviewModeResource.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.PreviewModeResource, MagicPreview.combo.ResourceBase);
+Ext.reg('magicpreview-combo-preview-mode-resource', MagicPreview.combo.PreviewModeResource);
+
+/**
+ * Panel Layout combo for resource settings.
  */
 MagicPreview.combo.PanelLayoutResource = function(config) {
     config = config || {};
     Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v', 'd'],
-            data: [
-                ['system_default', getSystemDefaultLabel()],
-                ['Overlay', 'Overlay'],
-                ['On Page', 'On Page']
-            ]
-        }),
-        displayField: 'd',
-        valueField: 'v',
-        mode: 'local',
-        triggerAction: 'all',
-        editable: false,
-        selectOnFocus: false,
-        preventRender: true,
-        forceSelection: true,
-        enableKeyEvents: true
+        rows: [['Overlay', 'Overlay'], ['On Page', 'On Page']]
     });
     MagicPreview.combo.PanelLayoutResource.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.PanelLayoutResource, MODx.combo.ComboBox);
+Ext.extend(MagicPreview.combo.PanelLayoutResource, MagicPreview.combo.ResourceBase);
 Ext.reg('magicpreview-combo-panel-layout-resource', MagicPreview.combo.PanelLayoutResource);
+
+/**
+ * Per-resource enabled override combo: System Default / Yes / No.
+ * Inherits from the template filter system setting when "System Default".
+ * Yes/No labels use MODX's core lexicon via the manager's _() helper.
+ */
+MagicPreview.combo.ResourceEnabled = function(config) {
+    config = config || {};
+    Ext.applyIf(config, {
+        rows: [
+            ['Yes', _('yes')],
+            ['No', _('no')]
+        ]
+    });
+    MagicPreview.combo.ResourceEnabled.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.ResourceEnabled, MagicPreview.combo.ResourceBase);
+Ext.reg('magicpreview-combo-resource-enabled', MagicPreview.combo.ResourceEnabled);

--- a/assets/components/magicpreview/js/combo.js
+++ b/assets/components/magicpreview/js/combo.js
@@ -45,11 +45,32 @@ MagicPreview.combo.Base = function(config) {
 Ext.extend(MagicPreview.combo.Base, MODx.combo.ComboBox);
 
 /**
+ * Base for system-settings combos, where the stored value is also the
+ * display label. Subclasses pass their values via config.values.
+ */
+MagicPreview.combo.SystemBase = function(config) {
+    config = config || {};
+    var values = config.values || [];
+    delete config.values;
+    Ext.applyIf(config, {
+        store: new Ext.data.SimpleStore({
+            fields: ['v'],
+            data: values.map(function(v) { return [v]; })
+        }),
+        displayField: 'v',
+        valueField: 'v'
+    });
+    MagicPreview.combo.SystemBase.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.SystemBase, MagicPreview.combo.Base);
+
+/**
  * Base for per-resource combos: prepends a localised "System Default" row
  * (value 'system_default', cleared to '' on save) ahead of the subclass's
  * own rows. Subclasses pass their [value, label] pairs via config.rows.
- * Rows are read at construction time so labels that depend on
- * MagicPreviewConfig (injected lazily) resolve correctly.
+ * The store is built per construction so the System Default label, read
+ * lazily from MagicPreviewConfig via getSystemDefaultLabel(), resolves once
+ * that global has been injected.
  */
 MagicPreview.combo.ResourceBase = function(config) {
     config = config || {};
@@ -75,16 +96,11 @@ Ext.extend(MagicPreview.combo.ResourceBase, MagicPreview.combo.Base);
 MagicPreview.combo.PreviewMode = function(config) {
     config = config || {};
     Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v'],
-            data: [['New Window'], ['Panel']]
-        }),
-        displayField: 'v',
-        valueField: 'v'
+        values: ['New Window', 'Panel']
     });
     MagicPreview.combo.PreviewMode.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.PreviewMode, MagicPreview.combo.Base);
+Ext.extend(MagicPreview.combo.PreviewMode, MagicPreview.combo.SystemBase);
 Ext.reg('magicpreview-combo-preview-mode', MagicPreview.combo.PreviewMode);
 
 /**
@@ -93,16 +109,11 @@ Ext.reg('magicpreview-combo-preview-mode', MagicPreview.combo.PreviewMode);
 MagicPreview.combo.PanelLayout = function(config) {
     config = config || {};
     Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v'],
-            data: [['Overlay'], ['On Page']]
-        }),
-        displayField: 'v',
-        valueField: 'v'
+        values: ['Overlay', 'On Page']
     });
     MagicPreview.combo.PanelLayout.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.PanelLayout, MagicPreview.combo.Base);
+Ext.extend(MagicPreview.combo.PanelLayout, MagicPreview.combo.SystemBase);
 Ext.reg('magicpreview-combo-panel-layout', MagicPreview.combo.PanelLayout);
 
 /**
@@ -111,16 +122,11 @@ Ext.reg('magicpreview-combo-panel-layout', MagicPreview.combo.PanelLayout);
 MagicPreview.combo.TemplateFilterMode = function(config) {
     config = config || {};
     Ext.applyIf(config, {
-        store: new Ext.data.SimpleStore({
-            fields: ['v'],
-            data: [['None'], ['Block Listed'], ['Allow Listed Only']]
-        }),
-        displayField: 'v',
-        valueField: 'v'
+        values: ['None', 'Block Listed', 'Allow Listed Only']
     });
     MagicPreview.combo.TemplateFilterMode.superclass.constructor.call(this, config);
 };
-Ext.extend(MagicPreview.combo.TemplateFilterMode, MagicPreview.combo.Base);
+Ext.extend(MagicPreview.combo.TemplateFilterMode, MagicPreview.combo.SystemBase);
 Ext.reg('magicpreview-combo-template-filter-mode', MagicPreview.combo.TemplateFilterMode);
 
 // -- Per-resource combos (include a "System Default" inherit option) ---------

--- a/assets/components/magicpreview/js/combo.js
+++ b/assets/components/magicpreview/js/combo.js
@@ -112,6 +112,71 @@ Ext.extend(MagicPreview.combo.PreviewModeResource, MODx.combo.ComboBox);
 Ext.reg('magicpreview-combo-preview-mode-resource', MagicPreview.combo.PreviewModeResource);
 
 /**
+ * Template Filter Mode combo for system settings.
+ */
+MagicPreview.combo.TemplateFilterMode = function(config) {
+    config = config || {};
+    Ext.applyIf(config, {
+        store: new Ext.data.SimpleStore({
+            fields: ['v'],
+            data: [
+                ['None'],
+                ['Block Listed'],
+                ['Allow Listed Only']
+            ]
+        }),
+        displayField: 'v',
+        valueField: 'v',
+        mode: 'local',
+        triggerAction: 'all',
+        editable: false,
+        selectOnFocus: false,
+        preventRender: true,
+        forceSelection: true,
+        enableKeyEvents: true
+    });
+    MagicPreview.combo.TemplateFilterMode.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.TemplateFilterMode, MODx.combo.ComboBox);
+Ext.reg('magicpreview-combo-template-filter-mode', MagicPreview.combo.TemplateFilterMode);
+
+/**
+ * Per-resource enabled override combo: System Default / Yes / No.
+ * Inherits from the template filter system setting when "System Default".
+ */
+MagicPreview.combo.ResourceEnabled = function(config) {
+    config = config || {};
+    var labelYes = (typeof MagicPreviewConfig !== 'undefined'
+        && MagicPreviewConfig.lexicon
+        && MagicPreviewConfig.lexicon.yes) || 'Yes';
+    var labelNo = (typeof MagicPreviewConfig !== 'undefined'
+        && MagicPreviewConfig.lexicon
+        && MagicPreviewConfig.lexicon.no) || 'No';
+    Ext.applyIf(config, {
+        store: new Ext.data.SimpleStore({
+            fields: ['v', 'd'],
+            data: [
+                ['system_default', getSystemDefaultLabel()],
+                ['Yes', labelYes],
+                ['No', labelNo]
+            ]
+        }),
+        displayField: 'd',
+        valueField: 'v',
+        mode: 'local',
+        triggerAction: 'all',
+        editable: false,
+        selectOnFocus: false,
+        preventRender: true,
+        forceSelection: true,
+        enableKeyEvents: true
+    });
+    MagicPreview.combo.ResourceEnabled.superclass.constructor.call(this, config);
+};
+Ext.extend(MagicPreview.combo.ResourceEnabled, MODx.combo.ComboBox);
+Ext.reg('magicpreview-combo-resource-enabled', MagicPreview.combo.ResourceEnabled);
+
+/**
  * Panel Layout combo for resource settings: includes a "System Default"
  * option (empty string value) that inherits from the system setting.
  */

--- a/assets/components/magicpreview/js/preview.js
+++ b/assets/components/magicpreview/js/preview.js
@@ -53,6 +53,8 @@
             panelLayout: MagicPreviewConfig.panelLayout ?? LAYOUT_OVERLAY,
             resourcePreviewMode: MagicPreviewConfig.resourcePreviewMode ?? '',
             resourcePanelLayout: MagicPreviewConfig.resourcePanelLayout ?? '',
+            resourceEnabled: MagicPreviewConfig.resourceEnabled ?? '',
+            previewHidden: !!MagicPreviewConfig.previewHidden,
             autoRefreshInterval: parseInt(MagicPreviewConfig.autoRefreshInterval, 10) || 0,
             breakpoints: MagicPreviewConfig.breakpoints ?? {},
             lexicon: MagicPreviewConfig.lexicon ?? {},
@@ -715,8 +717,16 @@
     // =========================================================================
 
     Ext.onReady(function() {
+        var hidden = !!config().previewHidden;
+
         // Initialise the panel sub-module with config
-        initPanelModule();
+        if (!hidden) {
+            // Marker class for CSS rules that should only apply when the
+            // Preview/Save Draft buttons are actually injected. Keeps the
+            // native View button untouched when MagicPreview is hidden.
+            Ext.getBody().addClass('magicpreview_active');
+            initPanelModule();
+        }
 
         // =================================================================
         // Per-resource settings: inject combos into the Settings tab
@@ -739,6 +749,14 @@
                     autoHeight: true,
                     defaults: { anchor: '100%' },
                     items: [
+                        {
+                            xtype: 'magicpreview-combo-resource-enabled',
+                            fieldLabel: c.lexicon.resource_enabled || 'Use Magic Preview?',
+                            description: '<b>[[*properties.magicpreview.enabled]]</b><br>' + (c.lexicon.resource_enabled_desc || ''),
+                            name: 'magicpreview_enabled',
+                            hiddenName: 'magicpreview_enabled',
+                            value: c.resourceEnabled || 'system_default'
+                        },
                         {
                             xtype: 'magicpreview-combo-preview-mode-resource',
                             fieldLabel: c.lexicon.resource_preview_mode || 'Preview Mode',
@@ -772,6 +790,15 @@
                 return fields.concat(getResourceSettingFields());
             }
         });
+
+        // If the Preview button is hidden for this resource (via the system
+        // template filter or a per-resource override), skip button injection,
+        // tooltips, panel onpage init, draft banner, auto-preview, and
+        // keyboard shortcuts. The Settings-tab combos above remain active so
+        // editors can flip the override back on without leaving the page.
+        if (hidden) {
+            return;
+        }
 
         // Override getButtons on the base UpdateResource prototype. Extras
         // like Collections, Articles, and LocationResources extend this class

--- a/core/components/magicpreview/elements/plugins/magicpreview.plugin.php
+++ b/core/components/magicpreview/elements/plugins/magicpreview.plugin.php
@@ -8,6 +8,11 @@ if (!defined('MAGICPREVIEW_MODE_PANEL')) {
     define('MAGICPREVIEW_MODE_WINDOW', 'New Window');
     define('MAGICPREVIEW_LAYOUT_OVERLAY', 'Overlay');
     define('MAGICPREVIEW_LAYOUT_ONPAGE', 'On Page');
+    define('MAGICPREVIEW_FILTER_NONE', 'None');
+    define('MAGICPREVIEW_FILTER_BLOCK', 'Block Listed');
+    define('MAGICPREVIEW_FILTER_ALLOW', 'Allow Listed Only');
+    define('MAGICPREVIEW_RESOURCE_ENABLED', 'Yes');
+    define('MAGICPREVIEW_RESOURCE_DISABLED', 'No');
 }
 
 $path = $modx->getOption('magicpreview.core_path', null, $modx->getOption('core_path') . 'components/magicpreview/');
@@ -40,8 +45,10 @@ switch ($modx->event->name) {
             $resourceProps = $resource->getProperties('magicpreview');
             $resourcePreviewMode = '';
             $resourcePanelLayout = '';
+            $resourceEnabled = '';
             $validModes = [MAGICPREVIEW_MODE_PANEL, MAGICPREVIEW_MODE_WINDOW];
             $validLayouts = [MAGICPREVIEW_LAYOUT_OVERLAY, MAGICPREVIEW_LAYOUT_ONPAGE];
+            $validEnabled = [MAGICPREVIEW_RESOURCE_ENABLED, MAGICPREVIEW_RESOURCE_DISABLED];
             if (is_array($resourceProps)) {
                 if (!empty($resourceProps['preview_mode']) && in_array($resourceProps['preview_mode'], $validModes, true)) {
                     $resourcePreviewMode = $resourceProps['preview_mode'];
@@ -51,9 +58,40 @@ switch ($modx->event->name) {
                     $resourcePanelLayout = $resourceProps['panel_layout'];
                     $jsConfig['panelLayout'] = $resourcePanelLayout;
                 }
+                if (!empty($resourceProps['enabled']) && in_array($resourceProps['enabled'], $validEnabled, true)) {
+                    $resourceEnabled = $resourceProps['enabled'];
+                }
             }
             $jsConfig['resourcePreviewMode'] = $resourcePreviewMode;
             $jsConfig['resourcePanelLayout'] = $resourcePanelLayout;
+            $jsConfig['resourceEnabled'] = $resourceEnabled;
+
+            // Decide whether the Preview button should be injected for this resource.
+            // Per-resource override wins; otherwise apply the system-wide template filter.
+            $previewHidden = false;
+            if ($resourceEnabled === MAGICPREVIEW_RESOURCE_DISABLED) {
+                $previewHidden = true;
+            } elseif ($resourceEnabled !== MAGICPREVIEW_RESOURCE_ENABLED) {
+                $filterMode = $modx->getOption('magicpreview.template_filter_mode', null, MAGICPREVIEW_FILTER_NONE);
+                if ($filterMode === MAGICPREVIEW_FILTER_BLOCK || $filterMode === MAGICPREVIEW_FILTER_ALLOW) {
+                    $rawIds = (string)$modx->getOption('magicpreview.template_filter_ids', null, '');
+                    $ids = [];
+                    foreach (explode(',', $rawIds) as $token) {
+                        $token = trim($token);
+                        if ($token !== '' && is_numeric($token)) {
+                            $ids[(int)$token] = true;
+                        }
+                    }
+                    $templateId = (int)$resource->get('template');
+                    $inList = isset($ids[$templateId]);
+                    if ($filterMode === MAGICPREVIEW_FILTER_BLOCK && $inList) {
+                        $previewHidden = true;
+                    } elseif ($filterMode === MAGICPREVIEW_FILTER_ALLOW && !$inList) {
+                        $previewHidden = true;
+                    }
+                }
+            }
+            $jsConfig['previewHidden'] = $previewHidden;
             $jsConfig['baseFrameUrl'] = $baseFrameUrl;
             $jsConfig['breakpoints'] = [
                 'desktop' => $modx->getOption('magicpreview.breakpoint_desktop', null, '1280px'),
@@ -83,6 +121,10 @@ switch ($modx->event->name) {
                 'resource_preview_mode_desc' => $modx->lexicon('magicpreview.resource_preview_mode_desc'),
                 'resource_panel_layout' => $modx->lexicon('magicpreview.resource_panel_layout'),
                 'resource_panel_layout_desc' => $modx->lexicon('magicpreview.resource_panel_layout_desc'),
+                'resource_enabled' => $modx->lexicon('magicpreview.resource_enabled'),
+                'resource_enabled_desc' => $modx->lexicon('magicpreview.resource_enabled_desc'),
+                'yes' => $modx->lexicon('yes'),
+                'no' => $modx->lexicon('no'),
                 'system_default' => $modx->lexicon('magicpreview.system_default'),
             ];
 
@@ -165,6 +207,7 @@ switch ($modx->event->name) {
         /** @var modResource|\MODX\Revolution\modResource $resource */
         $validModes = [MAGICPREVIEW_MODE_PANEL, MAGICPREVIEW_MODE_WINDOW];
         $validLayouts = [MAGICPREVIEW_LAYOUT_OVERLAY, MAGICPREVIEW_LAYOUT_ONPAGE];
+        $validEnabled = [MAGICPREVIEW_RESOURCE_ENABLED, MAGICPREVIEW_RESOURCE_DISABLED];
 
         $props = [];
         if (isset($_POST['magicpreview_preview_mode'])) {
@@ -174,6 +217,10 @@ switch ($modx->event->name) {
         if (isset($_POST['magicpreview_panel_layout'])) {
             $val = (string)$_POST['magicpreview_panel_layout'];
             $props['panel_layout'] = in_array($val, $validLayouts, true) ? $val : '';
+        }
+        if (isset($_POST['magicpreview_enabled'])) {
+            $val = (string)$_POST['magicpreview_enabled'];
+            $props['enabled'] = in_array($val, $validEnabled, true) ? $val : '';
         }
         if (!empty($props)) {
             $resource->setProperties($props, 'magicpreview');

--- a/core/components/magicpreview/elements/plugins/magicpreview.plugin.php
+++ b/core/components/magicpreview/elements/plugins/magicpreview.plugin.php
@@ -21,6 +21,15 @@ if (!($service instanceof MagicPreview)) {
     return 'Could not load MagicPreview service.';
 }
 
+// Per-resource override schema: property key => allowed values. Shared by the
+// read (OnDocFormRender) and write (OnDocFormSave) handlers so the whitelist
+// lives in one place. The matching POST field is 'magicpreview_<key>'.
+$mpOverrides = [
+    'preview_mode' => [MAGICPREVIEW_MODE_PANEL, MAGICPREVIEW_MODE_WINDOW],
+    'panel_layout' => [MAGICPREVIEW_LAYOUT_OVERLAY, MAGICPREVIEW_LAYOUT_ONPAGE],
+    'enabled'      => [MAGICPREVIEW_RESOURCE_ENABLED, MAGICPREVIEW_RESOURCE_DISABLED],
+];
+
 switch ($modx->event->name) {
     case 'OnDocFormRender':
         /** @var modResource|\MODX\Revolution\modResource $resource */
@@ -41,29 +50,28 @@ switch ($modx->event->name) {
             $jsConfig['panelLayout'] = $modx->getOption('magicpreview.panel_layout', null, MAGICPREVIEW_LAYOUT_OVERLAY);
             $jsConfig['autoRefreshInterval'] = (int)$modx->getOption('magicpreview.auto_refresh_interval', null, 5);
 
-            // Per-resource overrides: stored in the resource's properties column
+            // Per-resource overrides: stored in the resource's properties column.
+            // Each value is validated against its whitelist; anything else
+            // (including a missing key or the "system_default" sentinel) becomes
+            // an empty string, meaning "inherit the system setting".
             $resourceProps = $resource->getProperties('magicpreview');
-            $resourcePreviewMode = '';
-            $resourcePanelLayout = '';
-            $resourceEnabled = '';
-            $validModes = [MAGICPREVIEW_MODE_PANEL, MAGICPREVIEW_MODE_WINDOW];
-            $validLayouts = [MAGICPREVIEW_LAYOUT_OVERLAY, MAGICPREVIEW_LAYOUT_ONPAGE];
-            $validEnabled = [MAGICPREVIEW_RESOURCE_ENABLED, MAGICPREVIEW_RESOURCE_DISABLED];
-            if (is_array($resourceProps)) {
-                if (!empty($resourceProps['preview_mode']) && in_array($resourceProps['preview_mode'], $validModes, true)) {
-                    $resourcePreviewMode = $resourceProps['preview_mode'];
-                    $jsConfig['previewMode'] = $resourcePreviewMode;
-                }
-                if (!empty($resourceProps['panel_layout']) && in_array($resourceProps['panel_layout'], $validLayouts, true)) {
-                    $resourcePanelLayout = $resourceProps['panel_layout'];
-                    $jsConfig['panelLayout'] = $resourcePanelLayout;
-                }
-                if (!empty($resourceProps['enabled']) && in_array($resourceProps['enabled'], $validEnabled, true)) {
-                    $resourceEnabled = $resourceProps['enabled'];
-                }
+            $resourceValues = [];
+            foreach ($mpOverrides as $key => $valid) {
+                $val = is_array($resourceProps) && isset($resourceProps[$key]) ? $resourceProps[$key] : '';
+                $resourceValues[$key] = in_array($val, $valid, true) ? $val : '';
             }
-            $jsConfig['resourcePreviewMode'] = $resourcePreviewMode;
-            $jsConfig['resourcePanelLayout'] = $resourcePanelLayout;
+
+            // preview_mode / panel_layout overrides replace the effective
+            // system setting used by the rest of the page.
+            if ($resourceValues['preview_mode'] !== '') {
+                $jsConfig['previewMode'] = $resourceValues['preview_mode'];
+            }
+            if ($resourceValues['panel_layout'] !== '') {
+                $jsConfig['panelLayout'] = $resourceValues['panel_layout'];
+            }
+            $resourceEnabled = $resourceValues['enabled'];
+            $jsConfig['resourcePreviewMode'] = $resourceValues['preview_mode'];
+            $jsConfig['resourcePanelLayout'] = $resourceValues['panel_layout'];
             $jsConfig['resourceEnabled'] = $resourceEnabled;
 
             // Decide whether the Preview button should be injected for this resource.
@@ -123,8 +131,6 @@ switch ($modx->event->name) {
                 'resource_panel_layout_desc' => $modx->lexicon('magicpreview.resource_panel_layout_desc'),
                 'resource_enabled' => $modx->lexicon('magicpreview.resource_enabled'),
                 'resource_enabled_desc' => $modx->lexicon('magicpreview.resource_enabled_desc'),
-                'yes' => $modx->lexicon('yes'),
-                'no' => $modx->lexicon('no'),
                 'system_default' => $modx->lexicon('magicpreview.system_default'),
             ];
 
@@ -205,22 +211,14 @@ switch ($modx->event->name) {
 
     case 'OnDocFormSave':
         /** @var modResource|\MODX\Revolution\modResource $resource */
-        $validModes = [MAGICPREVIEW_MODE_PANEL, MAGICPREVIEW_MODE_WINDOW];
-        $validLayouts = [MAGICPREVIEW_LAYOUT_OVERLAY, MAGICPREVIEW_LAYOUT_ONPAGE];
-        $validEnabled = [MAGICPREVIEW_RESOURCE_ENABLED, MAGICPREVIEW_RESOURCE_DISABLED];
-
         $props = [];
-        if (isset($_POST['magicpreview_preview_mode'])) {
-            $val = (string)$_POST['magicpreview_preview_mode'];
-            $props['preview_mode'] = in_array($val, $validModes, true) ? $val : '';
-        }
-        if (isset($_POST['magicpreview_panel_layout'])) {
-            $val = (string)$_POST['magicpreview_panel_layout'];
-            $props['panel_layout'] = in_array($val, $validLayouts, true) ? $val : '';
-        }
-        if (isset($_POST['magicpreview_enabled'])) {
-            $val = (string)$_POST['magicpreview_enabled'];
-            $props['enabled'] = in_array($val, $validEnabled, true) ? $val : '';
+        foreach ($mpOverrides as $key => $valid) {
+            $postKey = 'magicpreview_' . $key;
+            if (isset($_POST[$postKey])) {
+                $val = (string)$_POST[$postKey];
+                // Invalid values (incl. the "system_default" sentinel) clear the override.
+                $props[$key] = in_array($val, $valid, true) ? $val : '';
+            }
         }
         if (!empty($props)) {
             $resource->setProperties($props, 'magicpreview');

--- a/core/components/magicpreview/lexicon/da/default.inc.php
+++ b/core/components/magicpreview/lexicon/da/default.inc.php
@@ -31,6 +31,10 @@ $_lang['setting_magicpreview.panel_layout'] = 'Panel-layout';
 $_lang['setting_magicpreview.panel_layout_desc'] = 'Hvordan forhåndsvisningspanelet interagerer med editoren. "Overlay" svæver ovenpå (standard). "On Page" formindsker editoren for en permanent kolonne.';
 $_lang['setting_magicpreview.auto_refresh_interval'] = 'Automatisk opdateringsinterval';
 $_lang['setting_magicpreview.auto_refresh_interval_desc'] = 'Sekunder mellem automatiske forhåndsvisningsopdateringer, mens panelet er åbent. Forhåndsvisningen opdateres kun, når formulardata er ændret. Sæt til 0 for at deaktivere. Standard: 5.';
+$_lang['setting_magicpreview.template_filter_mode'] = 'Skabelon-filtertilstand';
+$_lang['setting_magicpreview.template_filter_mode_desc'] = 'Begrænser hvor Forhåndsvisnings-knappen vises baseret på skabelon-ID. "None" viser knappen på alle ressourcer (standard). "Block Listed" skjuler knappen på ressourcer, der bruger et skabelon-ID på listen i "Skabelon-filter-ID\'er". "Allow Listed Only" viser kun knappen på ressourcer med et skabelon-ID på listen (en tom liste skjuler den overalt).';
+$_lang['setting_magicpreview.template_filter_ids'] = 'Skabelon-filter-ID\'er';
+$_lang['setting_magicpreview.template_filter_ids_desc'] = 'Komma-separeret liste af skabelon-ID\'er (f.eks. 1,5,12), der bruges af Skabelon-filtertilstand. Ignoreres, når tilstanden er "None".';
 
 // Kladder
 $_lang['magicpreview.save_draft'] = 'Gem kladde';
@@ -55,4 +59,6 @@ $_lang['magicpreview.resource_preview_mode'] = 'Forhåndsvisningstilstand';
 $_lang['magicpreview.resource_preview_mode_desc'] = 'Tilsidesæt den systemdækkende forhåndsvisningstilstand for denne ressource. Efterlad som "Systemstandard" for at arve systemindstillingen.';
 $_lang['magicpreview.resource_panel_layout'] = 'Panel-layout';
 $_lang['magicpreview.resource_panel_layout_desc'] = 'Tilsidesæt det systemdækkende panel-layout for denne ressource. Efterlad som "Systemstandard" for at arve systemindstillingen.';
+$_lang['magicpreview.resource_enabled'] = 'Brug Magic Preview?';
+$_lang['magicpreview.resource_enabled_desc'] = 'Tilsidesæt skabelonfilteret for denne ressource. "Ja" tvinger Forhåndsvisnings-knappen til at blive vist, selvom skabelonen er udelukket af systemfilteret. "Nej" skjuler knappen, selvom skabelonen ellers ville tillade det.';
 $_lang['magicpreview.system_default'] = 'Systemstandard';

--- a/core/components/magicpreview/lexicon/de/default.inc.php
+++ b/core/components/magicpreview/lexicon/de/default.inc.php
@@ -30,6 +30,10 @@ $_lang['setting_magicpreview.panel_layout'] = 'Panel-Layout';
 $_lang['setting_magicpreview.panel_layout_desc'] = 'Wie das Vorschau-Panel mit dem Editor interagiert. "Overlay" schwebt darüber (Standard). "On Page" verkleinert den Editor für eine permanente Spalte.';
 $_lang['setting_magicpreview.auto_refresh_interval'] = 'Automatisches Aktualisierungsintervall';
 $_lang['setting_magicpreview.auto_refresh_interval_desc'] = 'Sekunden zwischen automatischen Vorschau-Aktualisierungen, während das Panel geöffnet ist. Die Vorschau wird nur aktualisiert, wenn sich Formulardaten geändert haben. Auf 0 setzen zum Deaktivieren. Standard: 5.';
+$_lang['setting_magicpreview.template_filter_mode'] = 'Vorlagen-Filtermodus';
+$_lang['setting_magicpreview.template_filter_mode_desc'] = 'Begrenzt, wo der Vorschau-Button erscheint, basierend auf der Vorlagen-ID. "None" zeigt den Button für alle Ressourcen (Standard). "Block Listed" blendet den Button für Ressourcen mit einer in "Vorlagen-Filter-IDs" aufgelisteten Vorlagen-ID aus. "Allow Listed Only" zeigt den Button nur für Ressourcen mit aufgelisteter Vorlagen-ID (leere Liste blendet ihn überall aus).';
+$_lang['setting_magicpreview.template_filter_ids'] = 'Vorlagen-Filter-IDs';
+$_lang['setting_magicpreview.template_filter_ids_desc'] = 'Komma-separierte Liste von Vorlagen-IDs (z.B. 1,5,12), die vom Vorlagen-Filtermodus verwendet wird. Wird ignoriert, wenn der Modus "None" ist.';
 
 // Entwürfe
 $_lang['magicpreview.save_draft'] = 'Entwurf speichern';
@@ -54,4 +58,6 @@ $_lang['magicpreview.resource_preview_mode'] = 'Vorschau-Modus';
 $_lang['magicpreview.resource_preview_mode_desc'] = 'Überschreibt den systemweiten Vorschau-Modus für diese Ressource. Belassen Sie "Systemstandard", um die Systemeinstellung zu übernehmen.';
 $_lang['magicpreview.resource_panel_layout'] = 'Panel-Layout';
 $_lang['magicpreview.resource_panel_layout_desc'] = 'Überschreibt das systemweite Panel-Layout für diese Ressource. Belassen Sie "Systemstandard", um die Systemeinstellung zu übernehmen.';
+$_lang['magicpreview.resource_enabled'] = 'Magic Preview verwenden?';
+$_lang['magicpreview.resource_enabled_desc'] = 'Überschreibt den Vorlagenfilter für diese Ressource. "Ja" erzwingt, dass der Vorschau-Button erscheint, auch wenn die Vorlage durch den Systemfilter ausgeschlossen ist. "Nein" blendet den Button auch dann aus, wenn die Vorlage ihn sonst zulassen würde.';
 $_lang['magicpreview.system_default'] = 'Systemstandard';

--- a/core/components/magicpreview/lexicon/en/default.inc.php
+++ b/core/components/magicpreview/lexicon/en/default.inc.php
@@ -31,6 +31,10 @@ $_lang['setting_magicpreview.panel_layout'] = 'Panel Layout';
 $_lang['setting_magicpreview.panel_layout_desc'] = 'How the preview panel interacts with the editor. "Overlay" floats on top (default). "On Page" shrinks the editor to make room for a permanent column.';
 $_lang['setting_magicpreview.auto_refresh_interval'] = 'Auto Refresh Interval';
 $_lang['setting_magicpreview.auto_refresh_interval_desc'] = 'Seconds between automatic preview refreshes while the panel is open. The preview only refreshes when form data has changed. Set to 0 to disable. Default: 5.';
+$_lang['setting_magicpreview.template_filter_mode'] = 'Template Filter Mode';
+$_lang['setting_magicpreview.template_filter_mode_desc'] = 'Restrict where the Preview button appears based on template ID. "None" shows the button on every resource (default). "Block Listed" hides the button on resources using a template ID listed in Template Filter IDs. "Allow Listed Only" shows the button only on resources using a listed template ID (an empty list will hide it everywhere).';
+$_lang['setting_magicpreview.template_filter_ids'] = 'Template Filter IDs';
+$_lang['setting_magicpreview.template_filter_ids_desc'] = 'Comma-separated list of template IDs (e.g. 1,5,12) used by Template Filter Mode. Ignored when mode is "None".';
 
 // Drafts
 $_lang['magicpreview.save_draft'] = 'Save draft';
@@ -55,5 +59,7 @@ $_lang['magicpreview.resource_preview_mode'] = 'Preview Mode';
 $_lang['magicpreview.resource_preview_mode_desc'] = 'Override the system-wide preview mode for this resource. Leave as "System Default" to inherit the system setting.';
 $_lang['magicpreview.resource_panel_layout'] = 'Panel Layout';
 $_lang['magicpreview.resource_panel_layout_desc'] = 'Override the system-wide panel layout for this resource. Leave as "System Default" to inherit the system setting.';
+$_lang['magicpreview.resource_enabled'] = 'Use Magic Preview?';
+$_lang['magicpreview.resource_enabled_desc'] = 'Override the template filter for this resource. "Yes" forces the Preview button to appear even if the template is excluded by the system filter. "No" hides the button even if the template would otherwise allow it.';
 $_lang['magicpreview.system_default'] = 'System Default';
 


### PR DESCRIPTION
This adds 2 system settings. 

- `magicpreview.template_filter_mode`: `None`, `Block Listed` or `Allow Listed Only`. Toggle if template ids if template ids listed should block or allow.
- `magicpreview.template_filter_ids`: Comma separated list of template ids to block or allow depending on the value of the other system setting.

A `Use Magic Preview?` resource setting has also been added which overrides the template id system settings. `System Default`, `Yes` or `No`.